### PR TITLE
Fix: JSON overflows out of reCAPTCHA meta-box

### DIFF
--- a/admin/includes/meta-boxes.php
+++ b/admin/includes/meta-boxes.php
@@ -276,7 +276,7 @@ function flamingo_inbound_recaptcha_meta_box( $post ) {
 <?php foreach ( (array) $post->recaptcha as $key => $value ) : ?>
 <tr>
 <td class="field-title"><?php echo esc_html( $key ); ?></td>
-<td class="field-value"><?php echo esc_html( json_encode( $value ) ); ?></td>
+<td class="field-value"><?php echo esc_html( json_encode( $value, JSON_PRETTY_PRINT ) ); ?></td>
 </tr>
 <?php endforeach; ?>
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Flamingo ===
 Contributors: takayukister, megumithemes
 Tags: bird, contact, mail, crm
-Requires at least: 5.0
+Requires at least: 5.2
 Tested up to: 5.2
 Stable tag: 2.0
 License: GPLv2 or later


### PR DESCRIPTION
Fixed JSON overflows issue.

1. Updated `Requires at least: 5.2`
2. Updated `json_encode( $value, JSON_PRETTY_PRINT )` 

