### PR TITLE
Handle spam to trash cron job

### DIFF
--- a/flamingo.php
+++ b/flamingo.php
@@ -10,10 +10,6 @@ Version: 2.1
 
 define( 'FLAMINGO_VERSION', '2.1' );
 
-if ( ! defined( 'FLAMINGO_MOVE_TRASH_DAYS' ) ) {
-	define( 'FLAMINGO_MOVE_TRASH_DAYS', 30 );
-}
-
 define( 'FLAMINGO_PLUGIN', __FILE__ );
 
 define( 'FLAMINGO_PLUGIN_BASENAME',
@@ -24,6 +20,10 @@ define( 'FLAMINGO_PLUGIN_NAME',
 
 define( 'FLAMINGO_PLUGIN_DIR',
 	untrailingslashit( dirname( FLAMINGO_PLUGIN ) ) );
+
+if ( ! defined( 'FLAMINGO_MOVE_TRASH_DAYS' ) ) {
+	define( 'FLAMINGO_MOVE_TRASH_DAYS', 30 );
+}
 
 // Deprecated, not used in the plugin core. Use flamingo_plugin_url() instead.
 define( 'FLAMINGO_PLUGIN_URL',

--- a/flamingo.php
+++ b/flamingo.php
@@ -10,7 +10,9 @@ Version: 2.1
 
 define( 'FLAMINGO_VERSION', '2.1' );
 
-define( 'FLAMINGO_MOVE_TRASH_DAYS', 30 );
+if ( ! defined( 'FLAMINGO_MOVE_TRASH_DAYS' ) ) {
+	define( 'FLAMINGO_MOVE_TRASH_DAYS', 30 );
+}
 
 define( 'FLAMINGO_PLUGIN', __FILE__ );
 

--- a/flamingo.php
+++ b/flamingo.php
@@ -5,10 +5,12 @@ Description: A trustworthy message storage plugin for Contact Form 7.
 Author: Takayuki Miyoshi
 Text Domain: flamingo
 Domain Path: /languages/
-Version: 2.0
+Version: 3.0
 */
 
-define( 'FLAMINGO_VERSION', '2.0' );
+define( 'FLAMINGO_VERSION', '3.0' );
+
+define( 'FLAMINGO_MOVE_TRASH_DAYS', 30 );
 
 define( 'FLAMINGO_PLUGIN', __FILE__ );
 
@@ -35,6 +37,7 @@ require_once FLAMINGO_PLUGIN_DIR . '/includes/class-outbound-message.php';
 require_once FLAMINGO_PLUGIN_DIR . '/includes/user.php';
 require_once FLAMINGO_PLUGIN_DIR . '/includes/comment.php';
 require_once FLAMINGO_PLUGIN_DIR . '/includes/akismet.php';
+require_once FLAMINGO_PLUGIN_DIR . '/includes/cron.php';
 
 if ( is_admin() ) {
 	require_once FLAMINGO_PLUGIN_DIR . '/admin/admin.php';

--- a/flamingo.php
+++ b/flamingo.php
@@ -5,10 +5,10 @@ Description: A trustworthy message storage plugin for Contact Form 7.
 Author: Takayuki Miyoshi
 Text Domain: flamingo
 Domain Path: /languages/
-Version: 3.0
+Version: 2.1
 */
 
-define( 'FLAMINGO_VERSION', '3.0' );
+define( 'FLAMINGO_VERSION', '2.1' );
 
 define( 'FLAMINGO_MOVE_TRASH_DAYS', 30 );
 

--- a/includes/class-inbound-message.php
+++ b/includes/class-inbound-message.php
@@ -231,9 +231,11 @@ class Flamingo_Inbound_Message {
 			$this->id = $post_id;
 
 			if ( $post_status == self::spam_status ) {
+
 				// set spam meta time for later use to trash
 				update_post_meta( $post_id, '_spam_meta_time', time() );
 			} else {
+
 				// delete spam meta time to stop trashing in cron job
 				delete_post_meta( $post_id, '_spam_meta_time' );
 			}

--- a/includes/class-inbound-message.php
+++ b/includes/class-inbound-message.php
@@ -229,6 +229,15 @@ class Flamingo_Inbound_Message {
 
 		if ( $post_id ) {
 			$this->id = $post_id;
+
+			if ( $post_status == self::spam_status ) {
+				// set spam meta time for later use to trash
+				update_post_meta( $post_id, '_spam_meta_time', time() );
+			} else {
+				// delete spam meta time to stop trashing in cron job
+				delete_post_meta( $post_id, '_spam_meta_time' );
+			}
+
 			update_post_meta( $post_id, '_subject', $this->subject );
 			update_post_meta( $post_id, '_from', $this->from );
 			update_post_meta( $post_id, '_from_name', $this->from_name );

--- a/includes/cron.php
+++ b/includes/cron.php
@@ -3,7 +3,7 @@
 /**
  * The file that defines the cron job functionality
  *
- * @since 3.0
+ * @since 2.1
  *
  */
 
@@ -14,7 +14,7 @@ add_action( 'wp', 'flamingo_schedule_activation', 10, 0 );
 /**
  * Create schedule event for cron job, if its already not exists
  *
- * @since 3.0
+ * @since 2.1
  *
  * @see wp_next_scheduled(), wp_schedule_event()
  *
@@ -32,7 +32,7 @@ register_deactivation_hook( __FILE__, 'flamingo_schedule_deactivate' );
 /**
  * Function to deactivate the cron job
  *
- * @since 3.0
+ * @since 2.1
  *
  * @see wp_next_scheduled(), wp_unschedule_event()
  *
@@ -52,7 +52,7 @@ add_action( 'flamingo_daily_cron_job', 'flamingo_schedule_function', 10, 0 );
 /**
  * Function to run for cron job
  *
- * @since 3.0
+ * @since 2.1
  *
  * @see flamingo_schedule_move_trash()
  *

--- a/includes/cron.php
+++ b/includes/cron.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * The file that defines the cron job functionality
+ *
+ * @since 3.0
+ *
+ */
+
+
+/**
+ * Create schedule event for cron job, if its already not exists
+ *
+ * @since 3.0
+ *
+ * @see wp_next_scheduled(), wp_schedule_event()
+ *
+ */
+function flamingo_schedule_activation() {
+	if ( ! wp_next_scheduled( 'flamingo_daily_cron_job' ) ) {
+		wp_schedule_event( time(), 'daily', 'flamingo_daily_cron_job' );
+	}
+}
+
+// call when WP loads
+add_action( 'wp', 'flamingo_schedule_activation' );
+
+
+/**
+ * Function to deactivate the cron job
+ *
+ * @since 3.0
+ *
+ * @see wp_next_scheduled(), wp_unschedule_event()
+ *
+ */
+function flamingo_schedule_deactivate() {
+	// when the last event was scheduled
+	$timestamp = wp_next_scheduled( 'flamingo_daily_cron_job' );
+
+	// unschedule previous event if any
+	wp_unschedule_event( $timestamp, 'flamingo_daily_cron_job' );
+}
+
+// deactivate cron job on deactivation of the plugin on plugin's deactivation
+register_deactivation_hook( __FILE__, 'flamingo_schedule_deactivate' );
+
+
+/**
+ * Function to run for cron job
+ *
+ * @since 3.0
+ *
+ * @see flamingo_schedule_move_trash()
+ *
+ */
+function flamingo_schedule_function() {
+	// run function move spam to trash
+	flamingo_schedule_move_trash();
+}
+
+// hook flamingo_schedule_function to schedule event
+add_action( 'flamingo_daily_cron_job', 'flamingo_schedule_function' );

--- a/includes/cron.php
+++ b/includes/cron.php
@@ -48,6 +48,7 @@ function flamingo_schedule_deactivate() {
 
 // hook flamingo_schedule_function to schedule event
 add_action( 'flamingo_daily_cron_job', 'flamingo_schedule_function', 10, 0 );
+
 /**
  * Function to run for cron job
  *

--- a/includes/cron.php
+++ b/includes/cron.php
@@ -38,6 +38,7 @@ register_deactivation_hook( __FILE__, 'flamingo_schedule_deactivate' );
  *
  */
 function flamingo_schedule_deactivate() {
+
 	// when the last event was scheduled
 	$timestamp = wp_next_scheduled( 'flamingo_daily_cron_job' );
 
@@ -58,6 +59,7 @@ add_action( 'flamingo_daily_cron_job', 'flamingo_schedule_function', 10, 0 );
  *
  */
 function flamingo_schedule_function() {
+
 	// run function move spam to trash
 	flamingo_schedule_move_trash();
 }

--- a/includes/cron.php
+++ b/includes/cron.php
@@ -8,6 +8,9 @@
  */
 
 
+// call when WP loads
+add_action( 'wp', 'flamingo_schedule_activation', 10, 0 );
+
 /**
  * Create schedule event for cron job, if its already not exists
  *
@@ -22,9 +25,9 @@ function flamingo_schedule_activation() {
 	}
 }
 
-// call when WP loads
-add_action( 'wp', 'flamingo_schedule_activation' );
 
+// deactivate cron job on deactivation of the plugin on plugin's deactivation
+register_deactivation_hook( __FILE__, 'flamingo_schedule_deactivate' );
 
 /**
  * Function to deactivate the cron job
@@ -42,10 +45,9 @@ function flamingo_schedule_deactivate() {
 	wp_unschedule_event( $timestamp, 'flamingo_daily_cron_job' );
 }
 
-// deactivate cron job on deactivation of the plugin on plugin's deactivation
-register_deactivation_hook( __FILE__, 'flamingo_schedule_deactivate' );
 
-
+// hook flamingo_schedule_function to schedule event
+add_action( 'flamingo_daily_cron_job', 'flamingo_schedule_function', 10, 0 );
 /**
  * Function to run for cron job
  *
@@ -58,6 +60,3 @@ function flamingo_schedule_function() {
 	// run function move spam to trash
 	flamingo_schedule_move_trash();
 }
-
-// hook flamingo_schedule_function to schedule event
-add_action( 'flamingo_daily_cron_job', 'flamingo_schedule_function' );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -41,14 +41,17 @@ function flamingo_schedule_move_trash() {
 
 	global $wpdb;
 	$move_timestamp = time() - ( DAY_IN_SECONDS * FLAMINGO_MOVE_TRASH_DAYS );
+
 	// get posts ids Array to move to the trash
 	$posts_to_move = $wpdb->get_results( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_spam_meta_time' AND meta_value < %d", $move_timestamp ), ARRAY_A );
+
 	// post id's loop
 	foreach ( (array) $posts_to_move as $post ) {
 		$post_id = (int) $post['post_id'];
 		if ( ! $post_id ) {
 			continue;
 		}
+
 		// trash it now
 		wp_trash_post( $post_id );
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -33,6 +33,12 @@ function flamingo_array_flatten( $input ) {
  *
  */
 function flamingo_schedule_move_trash() {
+
+	// abort if FLAMINGO_MOVE_TRASH_DAYS is set to zero or in minus
+	if ( (int) FLAMINGO_MOVE_TRASH_DAYS <= 0 ) {
+		return true;
+	}
+
 	global $wpdb;
 	$move_timestamp = time() - ( DAY_IN_SECONDS * FLAMINGO_MOVE_TRASH_DAYS );
 	// get posts ids Array to move to the trash

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -48,6 +48,7 @@ function flamingo_schedule_move_trash() {
 	// post id's loop
 	foreach ( (array) $posts_to_move as $post_id ) {
 		$post_id = (int) $post_id;
+
 		if ( ! $post_id ) {
 			continue;
 		}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -23,3 +23,27 @@ function flamingo_array_flatten( $input ) {
 
 	return $output;
 }
+
+/**
+ * Move a spam to the Trash
+ *
+ * @since 3.0
+ *
+ * @see wp_trash_post()
+ *
+ */
+function flamingo_schedule_move_trash() {
+	global $wpdb;
+	$move_timestamp = time() - ( DAY_IN_SECONDS * FLAMINGO_MOVE_TRASH_DAYS );
+	// get posts ids Array to move to the trash
+	$posts_to_move = $wpdb->get_results( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_spam_meta_time' AND meta_value < %d", $move_timestamp ), ARRAY_A );
+	// post id's loop
+	foreach ( (array) $posts_to_move as $post ) {
+		$post_id = (int) $post['post_id'];
+		if ( ! $post_id ) {
+			continue;
+		}
+		// trash it now
+		wp_trash_post( $post_id );
+	}
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -27,7 +27,7 @@ function flamingo_array_flatten( $input ) {
 /**
  * Move a spam to the Trash
  *
- * @since 3.0
+ * @since 2.1
  *
  * @see wp_trash_post()
  *

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -43,11 +43,11 @@ function flamingo_schedule_move_trash() {
 	$move_timestamp = time() - ( DAY_IN_SECONDS * FLAMINGO_MOVE_TRASH_DAYS );
 
 	// get posts ids Array to move to the trash
-	$posts_to_move = $wpdb->get_results( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_spam_meta_time' AND meta_value < %d", $move_timestamp ), ARRAY_A );
+	$posts_to_move = $wpdb->get_col( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_spam_meta_time' AND meta_value < %d", $move_timestamp ) );
 
 	// post id's loop
-	foreach ( (array) $posts_to_move as $post ) {
-		$post_id = (int) $post['post_id'];
+	foreach ( (array) $posts_to_move as $post_id ) {
+		$post_id = (int) $post_id;
 		if ( ! $post_id ) {
 			continue;
 		}


### PR DESCRIPTION
I have added functionality to trash spam posts automatically after 30 days of spam post creation via a daily cron job schedule.

Here are the notes:
1. This update will apply to only new spam messages
2. When spam message will be created, a post meta will be saved with a timestamp for later use to find if it is ready to be trashed, the time to trash is set 30 days after creation.
3. If a post is trashed via Flamingo plugin, WordPress's default behavior will handle to delete permanently trash after 30 days.

I have updated version to 3.0 from 2.0 as we have made major changes in our current updates. before releasing on WP.org


I have tested this cron job functionality by applying interval of cron job to a few seconds instead of 30 days. 

