### PR TITLE
CSV: Improve the prefixing for field values

### DIFF
--- a/includes/csv.php
+++ b/includes/csv.php
@@ -15,15 +15,35 @@ function flamingo_csv_row( $inputs = array() ) {
 add_filter( 'flamingo_csv_quotation', 'flamingo_csv_quote' );
 
 function flamingo_csv_quote( $input ) {
-
-	// https://www.contextis.com/en/blog/comma-separated-vulnerabilities
-	if ( in_array( substr( $input, 0, 1 ), array( '=', '+', '-', '@' ), true ) ) {
-		$prefix = apply_filters( 'flamingo_csv_prefix_in_cell',
-			__( "(Security Alert: Suspicious content is detected. See https://contactform7.com/flamingo-211/ for details.)", 'flamingo' )
-		);
-
-		$input = trim( sprintf( '%1$s %2$s', $prefix, $input ) );
-	}
+	$prefix = apply_filters( 'flamingo_csv_field_prefix', '', $input );
+	$input = trim( sprintf( '%1$s %2$s', $prefix, $input ) );
 
 	return sprintf( '"%s"', str_replace( '"', '""', $input ) );
+}
+
+/*
+ * https://contactform7.com/2020/01/15/heads-up-about-spreadsheet-vulnerabilities/
+ */
+add_filter( 'flamingo_csv_field_prefix', 'flamingo_csv_field_prefix_text',
+	10, 2
+);
+
+function flamingo_csv_field_prefix_text( $prefix, $input ) {
+	$formula_triggers = array( '=', '+', '-', '@' );
+
+	if ( in_array( substr( $input, 0, 1 ), $formula_triggers, true ) ) {
+		/* translators: %s: URL */
+		$prefix = __( "(Security Alert: Suspicious content is detected. See %s for details.)", 'flamingo' );
+
+		if ( in_array( substr( $prefix, 0, 1 ), $formula_triggers, true ) ) {
+			$prefix = '\'' . $prefix;
+		}
+
+		$prefix = sprintf(
+			$prefix,
+			esc_url( __( 'https://contactform7.com/heads-up-about-spreadsheet-vulnerabilities', 'flamingo' ) )
+		);
+	}
+
+	return $prefix;
 }


### PR DESCRIPTION
1. Changes the filter name to flamingo_csv_field_prefix.
2. The default prefix is '', alter it with the default filter. You can disable this prefixing just by applying remove_filter() to the default filter.