### PR TITLE
Fix php warning

### DIFF
--- a/includes/class-inbound-message.php
+++ b/includes/class-inbound-message.php
@@ -205,9 +205,9 @@ class Flamingo_Inbound_Message {
 		}
 
 		$post_content = array_merge(
-			$this->fields,
-			$this->consent,
-			$this->meta
+			(array) $this->fields,
+			(array) $this->consent,
+			(array) $this->meta
 		);
 
 		$post_content = flamingo_array_flatten( $post_content );


### PR DESCRIPTION
Fix the PHP warning issue by making the following changes in the code. #18 

```
$post_content = array_merge(
       (array) $this->fields,
       (array) $this->consent,
       (array) $this->meta
);
```