### PR TITLE
Bulk actions at bottom doesn't work

### DIFF
--- a/admin/admin-functions.php
+++ b/admin/admin-functions.php
@@ -7,12 +7,12 @@ function flamingo_current_action() {
 	}
 
 	if ( isset( $_REQUEST['action'] )
-	and -1 !== $_REQUEST['action'] ) {
+	and -1 != $_REQUEST['action'] ) {
 		return $_REQUEST['action'];
 	}
 
 	if ( isset( $_REQUEST['action2'] )
-	and -1 !== $_REQUEST['action2'] ) {
+	and -1 != $_REQUEST['action2'] ) {
 		return $_REQUEST['action2'];
 	}
 


### PR DESCRIPTION
The posted value is a string, not an integer, so the variable should be compared to a string value, or use loose comparison. I prefer the latter.

See #52