### PR TITLE
Remove load_plugin_textdomain()

### DIFF
--- a/flamingo.php
+++ b/flamingo.php
@@ -48,9 +48,6 @@ if ( is_admin() ) {
 /* Init */
 
 add_action( 'init', function() {
-	/* L10N */
-	load_plugin_textdomain( 'flamingo', false, 'flamingo/languages' );
-
 	/* Custom Post Types */
 	Flamingo_Contact::register_post_type();
 	Flamingo_Inbound_Message::register_post_type();


### PR DESCRIPTION
`load_plugin_textdomain()` is no longer necessary as WordPress can [`_load_textdomain_just_in_time()`](https://developer.wordpress.org/reference/functions/_load_textdomain_just_in_time/)