### PR TITLE
Remove autogenerate date column in csv

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -708,7 +708,7 @@ function flamingo_load_inbound_admin() {
 		$labels = array_keys( $items[0]->fields );
 
 		echo flamingo_csv_row(
-			array_merge( $labels, array( __( 'Date', 'flamingo' ) ) ) );
+			array_merge( $labels, array( __( '', 'flamingo' ) ) ) );
 
 		foreach ( $items as $item ) {
 			$row = array();
@@ -724,8 +724,6 @@ function flamingo_load_inbound_admin() {
 
 				$row[] = $col;
 			}
-
-			$row[] = get_post_time( 'c', false, $item->id() ); // Date
 
 			echo "\r\n" . flamingo_csv_row( $row );
 		}


### PR DESCRIPTION
Hello,

I just made a patch that will remove the auto-generate date column in the csv file. This patch is made for those people who want to remove the auto-generate date column and add additional date fields by using `flamingo_add_inbound` hook, so we can filter the specific date format.

Thank you.